### PR TITLE
Update Mac Chrome Plugin for latest Chrome versions

### DIFF
--- a/chrome-extension/background.html
+++ b/chrome-extension/background.html
@@ -12,14 +12,7 @@
 <body>
 <embed id="pluginObj" type="application/x-depthjsplugin">
 
-<script>
-var pluginObj = document.getElementById('pluginObj');
-setTimeout(function() {
-  console.log('Starting DepthJS...');
-  if (!DepthJS.init(pluginObj)) {
-    console.log("Could not init DepthJS");
-  }
-}, 1000);
-</script>
+<script src="init_plugin.js"></script>
+
 </body>
 </html>

--- a/chrome-extension/chrome.js
+++ b/chrome-extension/chrome.js
@@ -240,7 +240,7 @@ DepthJS.browser.readdContentScriptListeners = function() {
 })();
 
 DepthJS.browser.sendMessageToPopup = function(msg) {
-  chrome.extension.sendRequest({action: msg});
+  chrome.extension.sendMessage({action: msg});
 };
 
 DepthJS.browser.sendMessageToActiveTab = function(message) {
@@ -263,7 +263,7 @@ DepthJS.browser.sendMessageToActiveTab = function(message) {
 };
 
 DepthJS.browser.sendMessageToBackground = function(messageType, data) {
-  chrome.extension.sendRequest({action: messageType, data: data});
+  chrome.extension.sendMessage({action: messageType, data: data});
 };
 
 } // if (DepthJS)

--- a/chrome-extension/content_script/selector_box.js
+++ b/chrome-extension/content_script/selector_box.js
@@ -24,13 +24,13 @@ DepthJS.selectorBox.hide = function() {
 DepthJS.selectorBox.move = function(x, y) {
   x = (x - 50) / 50.0;
   y = (y - 50) / 50.0;
-  
+
   // Expode out for a smaller range in Kinect-hand space
   x *= 1.5;
   y *= 1.5;
   x = Math.min(1, Math.max(-1, x));
   y = Math.min(1, Math.max(-1, y));
-  
+
   var hwidth = $(window).width() * 0.5;
   var hheight = $(window).height() * 0.5;
   x =  hwidth*x + hwidth;
@@ -156,7 +156,7 @@ DepthJS.selectorBoxPopup.move = function(x, y) {
   }
   var $closestLink = $("#DepthJS_popupItem" + closestLinkIndex);
   $closestLink.addClass("DepthJS_selectorBoxPopupItemHighlight");
-  
+
   DepthJS.selectorBoxPopup.lastHighlightedLinkIndex = closestLinkIndex;
   DepthJS.selectorBoxPopup.$lastHighlightedLink = $closestLink;
 };

--- a/chrome-extension/init_plugin.js
+++ b/chrome-extension/init_plugin.js
@@ -1,0 +1,7 @@
+var pluginObj = document.getElementById('pluginObj');
+setTimeout(function() {
+  console.log('Starting DepthJS...');
+  if (!DepthJS.init(pluginObj)) {
+    console.log("Could not init DepthJS");
+  }
+}, 1000);

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,11 +1,13 @@
 {
+  "manifest_version": 2,
+
   "version": "1.0.0",
 
   "name": "DepthJS",
 
   "description": "Connecting depth-aware cameras to Javascript",
 
-  "background_page": "background.html",
+  "background": {"page":"background.html"},
 
   "icons": {
     "16": "images/logo_16x16.png",
@@ -20,7 +22,7 @@
 
   "browser_action": {
     "default_icon": "images/logo_128x128.png",
-    "popup": "popup.html",
+    "default_popup": "popup.html",
     "default_title": "DepthJS"
   },
 

--- a/chrome-extension/plugin/depthjsplugin.plugin/Contents/Info.plist
+++ b/chrome-extension/plugin/depthjsplugin.plugin/Contents/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BuildMachineOSBuild</key>
+	<string>11E53</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
@@ -38,6 +40,20 @@
 	</dict>
 	<key>CFPlugInUnloadFunction</key>
 	<string></string>
+	<key>DTCompiler</key>
+	<string></string>
+	<key>DTPlatformBuild</key>
+	<string>4E3002</string>
+	<key>DTPlatformVersion</key>
+	<string>GM</string>
+	<key>DTSDKBuild</key>
+	<string>11E52</string>
+	<key>DTSDKName</key>
+	<string>macosx10.7</string>
+	<key>DTXcode</key>
+	<string>0433</string>
+	<key>DTXcodeBuild</key>
+	<string>4E3002</string>
 	<key>WebPluginDescription</key>
 	<string>The native plugin part of the DepthJS project</string>
 	<key>WebPluginMIMETypes</key>

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -1,0 +1,63 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<script src="third_party/jquery-1.4.4.min.js"></script>
+<script src="popup.js"></script>
+<style type="text/css">
+html, body {
+  font-family: "Lucida Grande", Arial, sans-serif;
+  font-size: 10pt;
+  color: #000;
+  text-align: left;
+  padding: 0;
+  margin: 0;
+  cursor: default;
+}
+
+ul {
+  padding: 5px 0px;
+  margin: 0;
+}
+
+li {
+  list-style-type: none;
+  margin: 0;
+  padding: 3px 10px;
+}
+
+li.disabled {
+  color: #999;
+}
+
+li.enabled:hover {
+  color-stop(0.22, #264BF3);
+  background: -webkit-gradient(
+    linear,
+    left bottom,
+    left top,
+    color-stop(0.22, #264BF3),
+    color-stop(0.87, #5170F7)
+  );
+  color: #fff;
+}
+
+</style>
+
+</head>
+<body>
+
+<ul>
+  <li class="server disabled" id="connect">Connect&nbsp;to&nbsp;Kinect</li>
+  <li class="server disabled" id="disconnect">Disconnect&nbsp;from&nbsp;Kinect</li>
+  <li><hr></li>
+  <li class="mode enabled" id="depthoseMode">Depthosé Mode</li>
+  <li class="mode enabled" id="pannerMode">Panner Mode</li>
+  <li class="mode enabled" id="selectorBoxMode">Selector Mode</li>
+  <li><hr></li>
+  <li class="test enabled" id="depthoseTest">Depthosé Test</li>
+  <li class="test enabled" id="pannerTest">Panner Test</li>
+  <li class="test enabled" id="selectorBoxTest">Selector Box Test</li>
+</ul>
+
+</body>
+</html>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -1,0 +1,47 @@
+  function connected() {
+    $("#disconnect").removeClass("disabled")
+                    .addClass("enabled");
+    $("#connect").removeClass("enabled")
+                 .addClass("disabled");
+   }
+
+  function disconnected() {
+    $("#connect").removeClass("disabled")
+                 .addClass("enabled");
+    $("#disconnect").removeClass("enabled")
+                    .addClass("disabled");
+  }
+
+  function connecting() {
+    $("li.server").removeClass("enabled")
+                  .addClass("disabled");
+  }
+
+  function updateMessage(msg) {
+    var state = msg.action || msg.state;
+    if (state == "connected") {
+      connected();
+    } else if (state == "disconnected") {
+      disconnected();
+    } else if (state == "connecting") {
+      connecting();
+    }
+
+    if (msg.mode != null) {
+      $(".mode").removeClass("disabled")
+                .addClass("enabled");
+      $("#" + msg.mode + "Mode").removeClass("enabled")
+                                .addClass("disabled");
+    }
+  }
+
+  jQuery(function() {
+    $(".enabled").live("click", function() {
+      chrome.extension.sendMessage({action: $(this).attr("id")});
+      window.close();
+    });
+
+    chrome.extension.sendMessage({action: "getConnectState"}, updateMessage);
+  });
+
+  chrome.extension.onRequest.addListener(updateMessage);


### PR DESCRIPTION
Great work, love the project! 
I am submitting code that makes the chrome plugin/extension work with the latest version of Chrome. There are several deprecated methods and other changes need to allow the extension  to install without errors. 
It has been tested on Mac Chrome Version 22.0.1229.94.

Changes:

changed chrome.extension.sendRequest to chrome.extensions.SendMessage
in chrome.js

Removed inline scripts in background.html and created initPlugin.js

added popup.html file from previous version and updated .sendMessage
Moved inlinescript from popup.html

Updated manifest to verson 2 and replaced background_page with
background.html and popup to default_popup
